### PR TITLE
fix: 修复渲染模版阶段找不到文件

### DIFF
--- a/packages/@mvc/cli-plugin-webpack/generator/template/build/base.config.js
+++ b/packages/@mvc/cli-plugin-webpack/generator/template/build/base.config.js
@@ -38,21 +38,6 @@ module.exports = {
                 test: /\.css$/,
                 use: ['style-loader', 'css-loader'],
             },
-            <%_ if (lintOnSave) { _%>
-            {
-                enforce: 'pre',
-                test: /\.(js|vue)$/,
-                loader: 'eslint-loader',
-                exclude: /node_modules/
-            },
-            <%_ } _%>
-            <%_ if (hasBabel) { _%>
-            {
-                test: /\.js$/,
-                loader: 'babel-loader',
-                exclude: /node_modules/,
-            },
-            <%_ } _%>
         ],
     },
     plugins: [

--- a/packages/@mvc/cli/lib/Generator.js
+++ b/packages/@mvc/cli/lib/Generator.js
@@ -283,17 +283,16 @@ class Generator {
 
         const replaceBlockRE = /<%# REPLACE %>([^]*?)<%# END_REPLACE %>/g
         if (parsed.extend) {
-            let extendPath
             if (parsed.extend.startsWith(':')) {
-                // 用户项目根目录
-                extendPath = path.join(process.cwd(), parsed.extend.slice(1))
+                // 用户项目根目录中的同名文件
+                finalTemplate = this.files[parsed.extend.slice(3)]
             } else {
-                extendPath = path.isAbsolute(parsed.extend)
+                const extendPath = path.isAbsolute(parsed.extend)
                     ? parsed.extend
                     : resolve.sync(parsed.extend, { basedir: path.dirname(name) })
+                finalTemplate = fs.readFileSync(extendPath, 'utf-8')
             }
 
-            finalTemplate = fs.readFileSync(extendPath, 'utf-8')
             if (parsed.replace) {
                 if (Array.isArray(parsed.replace)) {
                     const replaceMatch = content.match(replaceBlockRE)


### PR DESCRIPTION
1、多包管理模式下webpack包内不应该耦合Babel和linter的判断和代码
2、template中包含 `extend: ':./build/base.config.js'` 时 `finalTemplate = fs.readFileSync(extendPath, 'utf-8')` 获取的文件路径不对